### PR TITLE
Switch web server based on DJANGO_DEBUG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,21 @@ psql -U postgres
 
 The `background` container's `entrypoint.sh` auto-runs `migrate --noinput` on startup before launching `background.py`.
 
+## Managing work
+Use Nextcloud Deck as the source of truth.
+
+When starting work:
+
+- Select the top suitable card from Faults if one exists
+- If not select the top suitable card from Ready.
+- Move it to Doing.
+- Add a brief implementation note to the card.
+
+When implementation is complete:
+
+- Update the card with files changed, tests run, and any follow-up concerns.
+
+
 ## Architecture
 
 ### Two-process layout

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install libpq-dev gcc cma
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -r requirements.txt
 COPY . /code/
+COPY web-entrypoint.sh /usr/local/bin/web-entrypoint.sh
+RUN chmod +x /usr/local/bin/web-entrypoint.sh
 WORKDIR /code/bee/
+ENTRYPOINT ["/usr/local/bin/web-entrypoint.sh"]

--- a/web-entrypoint.sh
+++ b/web-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${DJANGO_DEBUG:-}" = "True" ] || [ "${DJANGO_DEBUG:-}" = "true" ]; then
+    echo "DEBUG mode: starting Django development server..."
+    exec python manage.py runserver 0.0.0.0:8005
+else
+    echo "PRODUCTION mode: collecting static files..."
+    python manage.py collectstatic --noinput
+    echo "PRODUCTION mode: starting Gunicorn..."
+    exec gunicorn bee.wsgi:application --bind 0.0.0.0:8005 --workers 3
+fi


### PR DESCRIPTION
## Problem
The web service always started Django's `runserver` regardless of the
`DJANGO_DEBUG` setting. `runserver` is single-threaded and not suitable
for production use.

## Solution
Add `web-entrypoint.sh` which reads `DJANGO_DEBUG` at container start
and launches the appropriate server:

| `DJANGO_DEBUG` | Server |
|---|---|
| `True` | `python manage.py runserver 0.0.0.0:8005` |
| `False` | `collectstatic --noinput` then `gunicorn` (3 workers, port 8005) |

`Dockerfile` is updated to copy the script in and set it as `ENTRYPOINT`.
No changes to `docker-compose.yml` are needed — `DJANGO_DEBUG` is already
declared in the `web` service's `environment` block and driven by `.env`.

## Testing
- `DJANGO_DEBUG=True` → container logs show `DEBUG mode: starting Django development server...` ✅
- `DJANGO_DEBUG=False` → container logs show `PRODUCTION mode:` + gunicorn starting 3 workers on port 8005 ✅
